### PR TITLE
DOC: fix typo in checkout action of the example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     
-      - uses: actions/checkout@v3                # clones your repo, make sure the ssh secret is set!
+      - uses: actions/checkout@v2                # clones your repo, make sure the ssh secret is set!
           
       - uses: joblo2213/aoc-badges-action@v3
         with:


### PR DESCRIPTION
The version used in the workflow does not exist,
so it's not possible to just copy the template and fill in the missing
values described in the setup section of the README.