### PR TITLE
Add the possibility to have one badge for multiple years

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,14 @@ You need to add this session id as [encrypted secret](https://docs.github.com/en
 
 Now you can set up the workflow. The sample workflow beyond will help you.  
 
+## Handle multiple years
+### Multiple badges
 If you want to set up badges for multiple years in one repository just add this action multiple times (once for each year using the `year` input).  
 Have slightly different badges for each year with a custom regex using the regex inputs.  
 The day badge probably doesn't makes sense for multiple years as it only depends on the current date (and therefore only works in December).
+
+### One badge
+If you want to have a custom badge to group multiple years in one repository just add all the years, separated by a comma, inside the `year:` optional input.
 
 ## Sample Workflow
 
@@ -67,7 +72,7 @@ jobs:
           
 #         Optional inputs:
 #         
-#         year: 2021                                                                                     # The year for which stats should be retrieved
+#         year: 2021                                                                                     # The year for which stats should be retrieved. Write 20XX,20XX to combine multiple years.
 #         leaderboard: 'https://adventofcode.com/2020/leaderboard/private/view/00000.json'               # The url of the leaderboard from witch the data is fetched. Typically your private leaderboard.
 #         file: 'README.md'                                                                              # The file that contains the badges
 #         dayRegex: '(?<=https:\/\/img\.shields\.io\/badge\/day%20📅-)[0-9]+(?=-blue)'                   # Regular expression that finds the content of the day badge in your file.

--- a/aoc-badges.py
+++ b/aoc-badges.py
@@ -47,7 +47,6 @@ for year in years:
     stars += data['members'][userid]['stars']
 
     # completed days
-    days_completed = 0
     for day in data['members'][userid]['completion_day_level']:
         if '2' in data['members'][userid]['completion_day_level'][day]:
             days_completed += 1

--- a/aoc-badges.py
+++ b/aoc-badges.py
@@ -7,7 +7,7 @@ from datetime import date, timedelta, datetime
 import pytz
 
 # environment variables
-year = os.getenv('INPUT_YEAR')
+years_array = os.getenv('INPUT_YEAR')
 leaderboard = os.getenv('INPUT_LEADERBOARD')
 session = os.getenv('INPUT_SESSION')
 readme = os.getenv('INPUT_FILE')
@@ -15,52 +15,59 @@ userid = os.getenv('INPUT_USERID')
 day_regex = os.getenv('INPUT_DAYREGEX')
 stars_regex = os.getenv('INPUT_STARSREGEX')
 days_completed_regex = os.getenv('INPUT_DAYSCOMPLETEDREGEX')
-if year is None or not year:
-    year = date.today().year
+if years_array is None or not years_array:
+    years = date.today().year
 else:
     try:
-        year = int(year)
+        years = list(map(int,years_array.split(',')))
     except ValueError:
         print('year input is not an integer')
         exit(1)
-if leaderboard is None or not leaderboard:
-    leaderboard = f'https://adventofcode.com/{year}/leaderboard/private/view/{userid}.json'
 
-# fetch stars
-cookie = {'session': session}
-print('Fetching leaderboard data from : ' + leaderboard)
-r = requests.get(leaderboard, cookies=cookie)
-if r.status_code != 200:
-    print(f'Leaderboard API returned status code {r.status_code}: {r.text}')
-    exit(1)
-try:
-    data = json.loads(r.text)
-except json.JSONDecodeError as err:
-    print('Could not parse leaderboard json. Is the leaderboard url correct & your session code valid?')
-    print(err)
-    exit(1)
-# noinspection PyUnboundLocalVariable
-stars = data['members'][userid]['stars']
-
-# completed days
+stars = 0
 days_completed = 0
-for day in data['members'][userid]['completion_day_level']:
-    if '2' in data['members'][userid]['completion_day_level'][day]:
-        days_completed += 1
+for year in years:
+    if leaderboard is None or not leaderboard:
+        leaderboard = f'https://adventofcode.com/{year}/leaderboard/private/view/{userid}.json'
 
-# Set the timezone to New York
-new_york_tz = pytz.timezone('America/New_York')
+    # fetch stars
+    cookie = {'session': session}
+    print('Fetching leaderboard data from : ' + leaderboard)
+    r = requests.get(leaderboard, cookies=cookie)
+    if r.status_code != 200:
+        print(f'Leaderboard API returned status code {r.status_code}: {r.text}')
+        exit(1)
+    try:
+        data = json.loads(r.text)
+    except json.JSONDecodeError as err:
+        print('Could not parse leaderboard json. Is the leaderboard url correct & your session code valid?')
+        print(err)
+        exit(1)
+    # noinspection PyUnboundLocalVariable
+    stars += data['members'][userid]['stars']
 
-# Get the current time in New York
-today = datetime.now(new_york_tz).date()
+    # completed days
+    days_completed = 0
+    for day in data['members'][userid]['completion_day_level']:
+        if '2' in data['members'][userid]['completion_day_level'][day]:
+            days_completed += 1
 
-# Your existing logic to determine the day
-if today < datetime(year, 12, 1, tzinfo=new_york_tz).date():
-    day = 0
-elif today > datetime(year, 12, 31, tzinfo=new_york_tz).date():
-    day = 24
-else:
-    day = today.day
+    # Set the timezone to New York
+    new_york_tz = pytz.timezone('America/New_York')
+
+    # Get the current time in New York
+    today = datetime.now(new_york_tz).date()
+
+    # Your existing logic to determine the day
+    if today < datetime(year, 12, 1, tzinfo=new_york_tz).date():
+        day = 0
+    elif today > datetime(year, 12, 31, tzinfo=new_york_tz).date():
+        day = 24
+    else:
+        day = today.day
+
+    # Reset the leaderboard for the next year iteration
+    leaderboard = None
 
 print(f'Day: {day}')
 print(f'Stars: {stars}')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-python ./aoc-badges.py
+python /aoc-badges.py

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-python /aoc-badges.py
+python ./aoc-badges.py


### PR DESCRIPTION
I noticed this action was not currently able to combine many years at once inside a badge. To display it inside the github profile repository for example. So I started to adapt your script a little to do it.

It's only after doing it, that I realized issues #5 or #10 where already mentionning something like this.
Like you said in one of them:

> Altough it should not add significant load it does still violate Eriks rule of only 1 request per 15min. I will strictly adhere to this rule.

My change cause this violation so I understand it might not fit your repository well. 
I still create the PR just for visiblity.
